### PR TITLE
feat: расширение тестов, стабилизация действий и CI

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,0 +1,51 @@
+name: CI Dev (fast)
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  build:
+    name: Build & Fast Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run fast tests with coverage
+        run: ./gradlew check --no-daemon
+
+      - name: Build plugin
+        run: ./gradlew buildPlugin --no-daemon
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: kover-html-report
+          path: build/reports/kover/html
+
+      - name: Build documentation (Dokka)
+        run: ./gradlew dokkaGenerateHtml --no-daemon
+
+      - name: Upload Dokka HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: dokka-html
+          path: build/dokka/html

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,18 +1,16 @@
-name: CI (fast)
+name: CI Main (fast)
 
 on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   build:
-    name: Build & Fast Tests
+    name: Build, Test & Verify
     runs-on: ubuntu-latest
 
     steps:
@@ -36,6 +34,9 @@ jobs:
 
       - name: Build plugin
         run: ./gradlew buildPlugin --no-daemon
+
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin --no-daemon
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 group = "ru.eda.plgn.bizgen"
-version = "1.10.242"
+version = "1.10.252"
 
 apply(from = "gradle/ic-version.gradle.kts")
 
@@ -38,12 +38,19 @@ repositories {
 }
 
 dependencies {
-  testImplementation(libs.bundles.test)
+  testImplementation(libs.bundles.test) {
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-test")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-test-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-jdk8")
+  }
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 
   intellijPlatform {
     // Unified Platform Distribution https://blog.jetbrains.com/platform/2025/11/intellij-platform-2025-3-what-plugin-developers-should-know/?utm_source=chatgpt.com
-    when(buildNumber.toInt() >= 252) {
+    when (buildNumber.toInt() >= 252) {
       true -> intellijIdea(icVersion) { useInstaller = false }
       else -> intellijIdeaCommunity(icVersion)
     }
@@ -51,6 +58,7 @@ dependencies {
     pluginVerifier()
     zipSigner()
     testFramework(TestFrameworkType.JUnit5)
+    testFramework(TestFrameworkType.Platform)
   }
 
   dokkaHtmlPlugin(libs.dokkaVersioningPlugin)
@@ -69,7 +77,7 @@ testing {
 intellijPlatform {
   pluginConfiguration {
     ideaVersion {
-      sinceBuild = buildNumber
+      sinceBuild = "242"
       untilBuild = provider { null }
     }
 
@@ -99,6 +107,13 @@ changelog {
 kover {
   reports {
     total {
+      filters {
+        excludes {
+          packages(
+            "ru.eda.plgn.bizgen.ui"
+          )
+        }
+      }
       xml { onCheck = true }
       html { onCheck = true }
     }
@@ -196,23 +211,4 @@ tasks {
   withType<DokkaGenerateTask>().configureEach {
     finalizedBy(copyKoverToDokka)
   }
-
-//  afterEvaluate {
-//    tasks.named("buildPlugin") {
-//      doLast {
-//        val jarDir = layout.buildDirectory.dir("libs").get().asFile
-//        val releasesDir = layout.projectDirectory.dir("releases").asFile
-//
-//        releasesDir.mkdirs()
-//
-//        val pluginName = "${rootProject.name}-$version.jar"
-//
-//        jarDir.listFiles { file -> file.name == pluginName }
-//          ?.forEach { jarFile ->
-//            println("Copying plugin ${jarFile.name} to releases folder")
-//            jarFile.copyTo(File(releasesDir, jarFile.name), overwrite = true)
-//          }
-//      }
-//    }
-//  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,8 @@ junit = "6.0.1" # https://mvnrepository.com/artifact/org.junit.jupiter/junit-jup
 kotest = "6.0.7" # https://plugins.gradle.org/plugin/io.kotest
 dokka = "2.1.0"  # https://plugins.gradle.org/plugin/org.jetbrains.dokka
 kover = "0.9.4"  # https://plugins.gradle.org/plugin/org.jetbrains.kotlinx.kover
-reflections = "0.10.2"
+reflections = "0.10.2" # https://mvnrepository.com/artifact/org.reflections/reflections
+mockk = "1.13.13" # https://mvnrepository.com/artifact/io.mockk/mockk
 
 [libraries]
 intellij-junit = { group = "junit", name = "junit", version.ref = "intellijJunit" }
@@ -17,6 +18,7 @@ junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", v
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
 dokkaVersioningPlugin = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 
 [plugins]
@@ -27,4 +29,4 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 
 [bundles]
-test = ["intellij-junit", "kotest-assertions-core", "junit-jupiter-api", "reflections"]
+test = ["intellij-junit", "kotest-assertions-core", "junit-jupiter-api", "reflections", "mockk"]

--- a/src/main/kotlin/ru/eda/plgn/bizgen/settings/model/BizGenAppSettings.kt
+++ b/src/main/kotlin/ru/eda/plgn/bizgen/settings/model/BizGenAppSettings.kt
@@ -9,7 +9,7 @@ import ru.eda.plgn.bizgen.di.getBizGenService
  *
  * @author Dmitry_Emelyanenko
  */
-class BizGenAppSettings {
+open class BizGenAppSettings {
 
   /** Режим уведомления. */
   var notificationMode: BizGenNotificationMode = BizGenNotificationMode.DISABLE
@@ -21,7 +21,7 @@ class BizGenAppSettings {
   var insToClipboard: Boolean = true
 
   /** Сброс настроек до значений по умолчанию. */
-  fun restoreFromDefault() {
+  open fun restoreFromDefault() {
     actualActions.clear()
     actualActions.addAll(BizGenDefaultAppSettings.getDefault().actualActions)
   }

--- a/src/main/resources/META-INF/description.html
+++ b/src/main/resources/META-INF/description.html
@@ -26,8 +26,8 @@ Ru BizGen is a generator of Russian-like test data for fast development.<br />
     <li>💰 <strong>Банковские реквизиты:</strong> расчетный счет (RUB, CNY), корреспонденский счет, БИК, SWIFT (российских банков), IBAN
       (РФ и Турция)
     </li>
-    <li>👤 <strong>ФИО:</strong> полное, сокращённое, инициалы</li>
-    <li>🏢 <strong>Юр. данные:</strong> ИНН (ФЛ и ЮР), ОГРН (ИП и ЮЛ), ОКТМО, КПП</li>
+    <li>👤 <strong>Физическое лицо:</strong> ФИО (полное, сокращённое, инициалы), ИНН, номер банковской карты</li>
+    <li>🏢 <strong>Юр. данные:</strong> ИНН, ОГРН (ИП и ЮЛ), ОКТМО (8 и 11 цифр), КПП, СНИЛС</li>
     <li>🏛️ <strong>Название организации:</strong> на русском и английском</li>
     <li>📍 <strong>Страна и Адрес:</strong> реалистичные форматы</li>
     <li>🔢 <strong>Прочее:</strong> UUID</li>
@@ -42,7 +42,8 @@ Ru BizGen is a generator of Russian-like test data for fast development.<br />
   <h4>Способы вызова:</h4>
   <ul>
     <li><code>Ctrl+Alt+E</code> (Windows/Linux) или <code>⌘⌥E</code> (Mac) — прямое открытие плагина</li>
-    <li><code>Alt+Ins</code> → <strong>Ru BizGen</strong> — через стандартное меню генерации кода IDEA</li>
+    <li><code>Alt+Ins</code> → <strong>BizGenMainAction</strong> — через стандартное меню генерации кода IDEA</li>
+    <li><code>Shift+Shift</code> (Search Everywhere) → BizGenMainAction</li>
   </ul>
   <p>Горячие клавиши можно изменить в настройках IDE.</p>
 </div>
@@ -79,4 +80,8 @@ Ru BizGen is a generator of Russian-like test data for fast development.<br />
     <li>💻 <strong>Удобство</strong> - работа прямо в редакторе</li>
     <li>🛠️ <strong>Для разработчиков</strong> - создано разработчиком для разработчиков</li>
   </ul>
+</div>
+
+<div class="tags">
+  <p><strong>Keywords:</strong> Russian test data generator, faker, INN, OGRN, KPP, SNILS, BIK, IBAN, SWIFT, random data, mock data, development utility, productivity tool, IntelliJ IDEA plugin.</p>
 </div>

--- a/src/test/kotlin/ru/eda/plgn/bizgen/BaseIdeaTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/BaseIdeaTest.kt
@@ -1,0 +1,77 @@
+package ru.eda.plgn.bizgen
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.junit5.RunInEdt
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.moduleFixture
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import com.intellij.testFramework.junit5.fixture.sourceRootFixture
+import com.intellij.testFramework.replaceService
+import io.mockk.mockk
+import ru.eda.plgn.bizgen.actions.BaseGeneratorAction
+import ru.eda.plgn.bizgen.di.BizGenService
+import ru.eda.plgn.bizgen.generators.Generator
+import ru.eda.plgn.bizgen.generators.GeneratorResult
+
+/**
+ * Базовая абстракция для интеграционных тестов.
+ *
+ * @author Dmitry_Emelyanenko
+ */
+@RunInEdt
+@TestApplication
+internal abstract class BaseIdeaTest : BaseTest() {
+
+  protected val projectFixture = projectFixture()
+  protected val moduleFixture = projectFixture.moduleFixture()
+  protected val sourceRootFixture = moduleFixture.sourceRootFixture()
+
+  /**
+   * Заменяет на заглушку сервис, который был создан на уровне приложения.
+   *
+   * @param T тип сервиса для замены
+   * @param disposable объект для управления временем жизни сервиса
+   * @return замененный сервис (заглушка)
+   */
+  inline fun <reified T : BizGenService> replaceServiceInApp(disposable: Disposable): T {
+    val service = mockk<T>()
+    ApplicationManager.getApplication().replaceService(T::class.java, service, disposable)
+    return service
+  }
+
+  /**
+   * Заменяет на переданный сервис, который был создан на уровне приложения.
+   *
+   * @param T тип сервиса для замены
+   * @param service объект сервиса
+   * @param disposable объект для управления временем жизни сервиса
+   * @return замененный сервис (заглушка)
+   */
+  inline fun <reified T : BizGenService> replaceServiceInApp(service: T, disposable: Disposable): T {
+    ApplicationManager.getApplication().replaceService(T::class.java, service, disposable)
+    return service
+  }
+
+  internal object TestGeneratorAction : BaseGeneratorAction<String>(
+    id = "test.generator",
+    name = "Test Generator",
+    generator = TestGenerator()
+  )
+
+  internal object TestGeneratorEmptyAction : BaseGeneratorAction<String>(
+    id = "test.generator.empty",
+    name = "Test Generator.empty",
+    generator = TestEmptyGenerator()
+  )
+
+  private class TestGenerator : Generator<String> {
+    override val uniqueDistance: Int = 1_000
+    override fun generate(): GeneratorResult<String> = GeneratorResult(toEditor = "TEST", toClipboard = "TEST")
+  }
+
+  private class TestEmptyGenerator : Generator<String> {
+    override val uniqueDistance: Int = 0
+    override fun generate(): GeneratorResult<String> = GeneratorResult(toEditor = "", toClipboard = "")
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/ObjectExtTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/ObjectExtTest.kt
@@ -1,0 +1,49 @@
+package ru.eda.plgn.bizgen
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+
+/**
+ * Модульный тест для [deepCopyByJson].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class ObjectExtTest : BaseTest() {
+
+  internal data class TestData(val name: String, val age: Int, val nested: NestedData? = null)
+  internal data class NestedData(val value: String)
+
+  @TestFactory
+  fun `Should perform deep copy of an object`() =
+    tests(
+      listOf(
+        TestData("Original", 25, NestedData("Nested")),
+        TestData("Another", 30, null)
+      ),
+      { "Deep copy test: $it" }
+    ) { original ->
+      val copy = original.deepCopyByJson()
+
+      copy shouldBe original
+      copy shouldNotBeSameInstanceAs original
+      if (original.nested != null) {
+        copy.nested shouldNotBeSameInstanceAs original.nested
+      }
+    }
+
+  @Test
+  fun `Should preserve data after modification of the copy`() {
+    val original = TestData("Original", 25, NestedData("Value"))
+
+    val copy = original.deepCopyByJson()
+    val modifiedCopy = copy.copy(name = "Modified", nested = NestedData("NewValue"))
+
+    modifiedCopy.name shouldBe "Modified"
+    original.name shouldBe "Original"
+
+    modifiedCopy.nested?.value shouldBe "NewValue"
+    original.nested?.value shouldBe "Value"
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/actions/BaseGeneratorActionTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/actions/BaseGeneratorActionTest.kt
@@ -1,0 +1,124 @@
+package ru.eda.plgn.bizgen.actions
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue
+import com.intellij.testFramework.TestActionEvent
+import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.fixture.editorFixture
+import com.intellij.testFramework.junit5.fixture.psiFileFixture
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import ru.eda.plgn.bizgen.clipboard.BizGenClipboardSettingsServiceView
+import ru.eda.plgn.bizgen.notification.NotificationCtx
+import ru.eda.plgn.bizgen.notification.NotificationService
+
+/**
+ * Интеграционные тесты для [BaseGeneratorAction].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BaseGeneratorActionTest : BaseIdeaTest() {
+  private val fileFixture = sourceRootFixture.psiFileFixture("test.txt", "ABC")
+  private val editorFixture = fileFixture.editorFixture()
+
+  @Test
+  fun `Should inserts generated text without notifications`(@TestDisposable disposable: Disposable) {
+    val editor = editorFixture.get()
+    val project = projectFixture.get()
+    val (clipboardService, notificationService) = configureProject(disposable)
+
+    every { clipboardService.needToIns() } returns false
+
+    callAction(editor, project)
+
+    editor.document.text shouldBe "TESTABC"
+    notificationService.count shouldBe 0
+  }
+
+  @Test
+  fun `Should inserts generated text with notifications`(@TestDisposable disposable: Disposable) {
+    val editor = editorFixture.get()
+    val project = projectFixture.get()
+    val (clipboardService, notificationService) = configureProject(disposable)
+
+    every { clipboardService.needToIns() } returns true
+
+    callAction(editor, project)
+
+    editor.document.text shouldBe "TESTABC"
+    notificationService.count shouldBe 1
+  }
+
+  @Test
+  fun `Should not inserts generated text when generator return empty text`(@TestDisposable disposable: Disposable) {
+    val editor = editorFixture.get()
+    val project = projectFixture.get()
+    val (clipboardService, notificationService) = configureProject(disposable)
+
+    every { clipboardService.needToIns() } returns true
+
+    callAction(editor, project, TestGeneratorEmptyAction)
+
+    editor.document.text shouldBe "ABC"
+    notificationService.count shouldBe 0
+  }
+
+  @Test
+  fun `Should return when event not contain editor`(@TestDisposable disposable: Disposable) {
+    val editor = editorFixture.get()
+    val project = projectFixture.get()
+    val (clipboardService, notificationService) = configureProject(disposable)
+
+    every { clipboardService.needToIns() } returns true
+
+    callAction(editor = null, project = project)
+
+    editor.document.text shouldBe "ABC"
+    notificationService.count shouldBe 0
+  }
+
+  @Test
+  fun `Should return when event not contain project`(@TestDisposable disposable: Disposable) {
+    val editor = editorFixture.get()
+    val (clipboardService, notificationService) = configureProject(disposable)
+
+    every { clipboardService.needToIns() } returns true
+
+    callAction(editor = editor, project = null)
+
+    editor.document.text shouldBe "ABC"
+    notificationService.count shouldBe 0
+  }
+
+  fun configureProject(disposable: Disposable): Pair<BizGenClipboardSettingsServiceView, FakeNotification> {
+    val clipboardSettingsService = replaceServiceInApp<BizGenClipboardSettingsServiceView>(disposable)
+    val notificationService = replaceServiceInApp<NotificationService>(FakeNotification(), disposable) as FakeNotification
+
+    return clipboardSettingsService to notificationService
+  }
+
+  fun callAction(editor: Editor?, project: Project?, action: BaseGeneratorAction<String> = TestGeneratorAction) {
+    val dataContext = SimpleDataContext.builder()
+      .add(CommonDataKeys.EDITOR, editor)
+      .add(CommonDataKeys.PROJECT, project)
+      .build()
+
+    val event = TestActionEvent.createTestEvent(action, dataContext)
+
+    action.actionPerformed(event)
+
+    dispatchAllInvocationEventsInIdeEventQueue()
+  }
+
+  internal class FakeNotification(var count: Int = 0) : NotificationService {
+    override fun sendNotification(ctx: NotificationCtx<*>) {
+      count++
+    }
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/actions/BizGenSelectedActionEventTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/actions/BizGenSelectedActionEventTest.kt
@@ -1,0 +1,53 @@
+package ru.eda.plgn.bizgen.actions
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Интеграционные тесты для [BizGenSelectedActionEvent].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BizGenSelectedActionEventTest : BaseIdeaTest() {
+
+  @TestFactory
+  fun `Should publish and receive selected action`(@TestDisposable disposable: Disposable) =
+    tests(listOf(mockk<GeneratorAction<*>>()), { "Publish action: $it" }) { action ->
+      val receivedAction = AtomicReference<GeneratorAction<*>>()
+
+      BizGenSelectedActionEvent.subscribeAsync(disposable) { generator ->
+        receivedAction.set(generator)
+      }
+
+      BizGenSelectedActionEvent.publish(action)
+
+      dispatchAllInvocationEventsInIdeEventQueue()
+
+      receivedAction.get() shouldBe action
+    }
+
+  @Test
+  fun `Should handle multiple publications`(@TestDisposable disposable: Disposable) {
+    val receivedActions = mutableListOf<GeneratorAction<*>>()
+    val action1 = mockk<GeneratorAction<*>>()
+    val action2 = mockk<GeneratorAction<*>>()
+
+    BizGenSelectedActionEvent.subscribeAsync(disposable) { generator ->
+      receivedActions.add(generator)
+    }
+
+    BizGenSelectedActionEvent.publish(action1)
+    BizGenSelectedActionEvent.publish(action2)
+
+    dispatchAllInvocationEventsInIdeEventQueue()
+
+    receivedActions shouldBe listOf(action1, action2)
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/actions/GeneratorActionProviderTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/actions/GeneratorActionProviderTest.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KClass
  *
  * @author Dmitry_Emelyanenko
  */
-class GeneratorActionProviderImplTest {
+class GeneratorActionProviderTest {
 
   val provider: GeneratorActionProvider = GeneratorActionProviderImpl()
 
@@ -43,8 +43,10 @@ class GeneratorActionProviderImplTest {
 
   companion object {
     fun <T : Any> findImplemented(baseClass: KClass<T>): List<Class<out T>> {
-      return Reflections(baseClass.java.packageName, Scanners.SubTypes).getSubTypesOf(baseClass.java)
+      return Reflections(baseClass.java.packageName, Scanners.SubTypes).getSubTypesOf(baseClass.java).asSequence()
         .filterNot { it.isInterface || java.lang.reflect.Modifier.isAbstract(it.modifiers) }
+        .filterNot { it.name.contains(".Test") }
+        .toList()
     }
   }
 }

--- a/src/test/kotlin/ru/eda/plgn/bizgen/clipboard/BizGenClipboardSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/clipboard/BizGenClipboardSettingsServiceTest.kt
@@ -1,0 +1,46 @@
+package ru.eda.plgn.bizgen.clipboard
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.TestFactory
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import ru.eda.plgn.bizgen.settings.BizGenAppSettingsRepository
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings
+
+/**
+ * Интеграционные тесты для [BizGenClipboardSettingsService].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BizGenClipboardSettingsServiceTest : BaseIdeaTest() {
+  private val underTest: BizGenClipboardSettingsService = BizGenClipboardSettingsServiceImpl()
+
+  @TestFactory
+  fun `Should return current clipboard setting`(@TestDisposable disposable: Disposable) =
+    tests(listOf(true, false), { "Clipboard setting: $it" }) { flag ->
+      val repository = replaceServiceInApp<BizGenAppSettingsRepository>(disposable)
+      val settings = mockk<BizGenAppSettings>()
+
+      every { repository.settings() } returns settings
+      every { settings.insToClipboard } returns flag
+
+      underTest.needToIns() shouldBe flag
+    }
+
+  @TestFactory
+  fun `Should update clipboard setting`(@TestDisposable disposable: Disposable) =
+    tests(listOf(true, false), { "Clipboard setting: $it" }) { flag ->
+      val repository = replaceServiceInApp<BizGenAppSettingsRepository>(disposable)
+      val settings = mockk<BizGenAppSettings>(relaxed = true)
+
+      every { repository.settings() } returns settings
+
+      underTest.setClipboardSetting(flag)
+
+      verify { settings.insToClipboard = flag }
+    }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/notification/NotificationServiceTest.kt
@@ -1,0 +1,99 @@
+package ru.eda.plgn.bizgen.notification
+
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.popup.BalloonBuilder
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import ru.eda.plgn.bizgen.generators.GeneratorResult
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings
+
+/**
+ * Интеграционные тесты для [NotificationService].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class NotificationServiceTest : BaseIdeaTest() {
+  private val underTest: NotificationService = NotificationServiceImpl()
+
+  @TestFactory
+  fun `Should send notification based on settings`(@TestDisposable disposable: Disposable) =
+    tests(
+      listOf(
+        BizGenAppSettings.BizGenNotificationMode.BELL,
+        BizGenAppSettings.BizGenNotificationMode.DISABLE
+      ),
+      { "Notification mode: $it" }
+    ) { mode ->
+      val settings = replaceServiceInApp<NotificationSettingsView>(disposable)
+
+      every { settings.getNotificationMode() } returns mode
+
+      val receivedNotifications = mutableListOf<Notification>()
+      ApplicationManager.getApplication().messageBus.connect(disposable).subscribe(
+        Notifications.TOPIC,
+        object : Notifications {
+          override fun notify(notification: Notification) {
+            receivedNotifications.add(notification)
+          }
+        }
+      )
+
+      val ctx = NotificationCtx(
+        actionInfo = NotificationCtx.ActionInfo("id", "Test Action"),
+        editor = mockk(relaxed = true),
+        result = GeneratorResult(toEditor = "Editor", toClipboard = "Clipboard")
+      )
+
+      underTest.sendNotification(ctx)
+
+      if (mode == BizGenAppSettings.BizGenNotificationMode.BELL) {
+        receivedNotifications.size shouldBe 1
+        receivedNotifications.first().content shouldBe "Clipboard добавлен в буфер"
+      } else {
+        receivedNotifications.size shouldBe 0
+      }
+    }
+
+  @Test
+  fun `Should show hint notification`(@TestDisposable disposable: Disposable) {
+    val settings = replaceServiceInApp<NotificationSettingsView>(disposable)
+    every { settings.getNotificationMode() } returns BizGenAppSettings.BizGenNotificationMode.HINT
+
+    val popupFactory = mockk<JBPopupFactory>()
+    val builder = mockk<BalloonBuilder>(relaxed = true)
+    every { builder.setFadeoutTime(any()) } returns builder
+
+    val balloon = mockk<com.intellij.openapi.ui.popup.Balloon>(relaxed = true)
+
+    mockkStatic(JBPopupFactory::class)
+    every { JBPopupFactory.getInstance() } returns popupFactory
+    every { popupFactory.createHtmlTextBalloonBuilder(any(), any(), any(), any()) } returns builder
+    every { popupFactory.guessBestPopupLocation(any<com.intellij.openapi.editor.Editor>()) } returns mockk(relaxed = true)
+    every { builder.createBalloon() } returns balloon
+
+    val ctx = NotificationCtx(
+      actionInfo = NotificationCtx.ActionInfo("id", "Test Action"),
+      editor = mockk(relaxed = true),
+      result = GeneratorResult(toEditor = "Editor", toClipboard = "Clipboard")
+    )
+
+    underTest.sendNotification(ctx)
+
+    verify { popupFactory.createHtmlTextBalloonBuilder("Clipboard добавлен в буфер", any(), any(), any()) }
+    verify { builder.createBalloon() }
+
+    unmockkStatic(JBPopupFactory::class)
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/settings/AppActionSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/settings/AppActionSettingsServiceTest.kt
@@ -1,0 +1,127 @@
+package ru.eda.plgn.bizgen.settings
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings.PersistenceActionSetting
+
+/**
+ * Интеграционные тесты для [AppActionSettingsService].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class AppActionSettingsServiceTest : BaseIdeaTest() {
+  private val underTest: AppActionSettingsService = AppActionSettingsServiceImpl()
+
+  @TestFactory
+  fun `Should find action by position`(@TestDisposable disposable: Disposable) =
+    tests(listOf(0, 1), { "Find by position: $it" }) { position ->
+      val (settings, _) = configureMocks(disposable)
+      val action = PersistenceActionSetting(id = "id-$position", position = position)
+
+      every { settings.actualActions } returns mutableListOf(action)
+
+      underTest.findByPosition(position) shouldBe action
+    }
+
+  @Test
+  fun `Should change activity of an action`(@TestDisposable disposable: Disposable) {
+    val (settings, _) = configureMocks(disposable)
+    val action = PersistenceActionSetting(id = "test", position = 0, active = false)
+
+    every { settings.actualActions } returns mutableListOf(action)
+
+    underTest.changeActivity(0, true)
+
+    action.active shouldBe true
+  }
+
+  @TestFactory
+  fun `Should move action in specified direction`(@TestDisposable disposable: Disposable) =
+    tests(
+      listOf(
+        Triple(0, AppActionSettingsService.Direction.DOWN, true),
+        Triple(1, AppActionSettingsService.Direction.UP, true),
+        Triple(0, AppActionSettingsService.Direction.UP, false),
+        Triple(1, AppActionSettingsService.Direction.DOWN, false)
+      ),
+      { "Move from ${it.first} to ${it.second}, expected success: ${it.third}" }
+    ) { (pos, dir, success) ->
+      val (settings, _) = configureMocks(disposable)
+      val action0 = PersistenceActionSetting(id = "0", position = 0)
+      val action1 = PersistenceActionSetting(id = "1", position = 1)
+
+      every { settings.actualActions } returns mutableListOf(action0, action1)
+
+      underTest.moveTo(pos, dir) shouldBe success
+
+      if (success) {
+        if (pos == 0) {
+          action0.position shouldBe 1
+          action1.position shouldBe 0
+        } else {
+          action0.position shouldBe 1
+          action1.position shouldBe 0
+        }
+      }
+    }
+
+  @Test
+  fun `Should return all action settings sorted by position`(@TestDisposable disposable: Disposable) {
+    val (settings, _) = configureMocks(disposable)
+    val action0 = PersistenceActionSetting(id = "0", position = 0)
+    val action1 = PersistenceActionSetting(id = "1", position = 1)
+
+    every { settings.actualActions } returns mutableListOf(action1, action0)
+
+    underTest.getActionSettings() shouldContainExactly listOf(action0, action1)
+  }
+
+  @Test
+  fun `Should return only active action settings`(@TestDisposable disposable: Disposable) {
+    val (settings, _) = configureMocks(disposable)
+    val action0 = PersistenceActionSetting(id = "0", position = 0, active = true)
+    val action1 = PersistenceActionSetting(id = "1", position = 1, active = false)
+
+    every { settings.actualActions } returns mutableListOf(action0, action1)
+
+    underTest.getActiveActionSettings() shouldContainExactly listOf(action0)
+  }
+
+  @Test
+  fun `Should restore settings to default`(@TestDisposable disposable: Disposable) {
+    val repository = replaceServiceInApp<BizGenAppSettingsRepository>(disposable)
+    val settings = object : BizGenAppSettings() {
+      var restoreCalled = false
+      override fun restoreFromDefault() {
+        restoreCalled = true
+      }
+    }
+
+    every { repository.settings() } returns settings
+
+    underTest.restoreByDefault()
+
+    settings.restoreCalled shouldBe true
+  }
+
+  private fun configureMocks(disposable: Disposable): Pair<BizGenAppSettings, BizGenAppSettingsRepository> {
+    replaceServiceInApp<ru.eda.plgn.bizgen.actions.GeneratorActionProvider>(disposable).apply {
+      every { getActions() } returns emptyList()
+    }
+
+    val repository = replaceServiceInApp<BizGenAppSettingsRepository>(disposable)
+    val settings = mockk<BizGenAppSettings>(relaxed = true)
+
+    every { repository.settings() } returns settings
+
+    return settings to repository
+  }
+}

--- a/src/test/kotlin/ru/eda/plgn/bizgen/settings/persistent/BizGenAppSettingsPersistentTest.kt
+++ b/src/test/kotlin/ru/eda/plgn/bizgen/settings/persistent/BizGenAppSettingsPersistentTest.kt
@@ -1,0 +1,67 @@
+package ru.eda.plgn.bizgen.settings.persistent
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import ru.eda.plgn.bizgen.BaseIdeaTest
+import ru.eda.plgn.bizgen.actions.GeneratorAction
+import ru.eda.plgn.bizgen.actions.GeneratorActionProvider
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings
+import ru.eda.plgn.bizgen.settings.model.BizGenAppSettings.PersistenceActionSetting
+
+/**
+ * Интеграционные тесты для [BizGenAppSettingsPersistent].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BizGenAppSettingsPersistentTest : BaseIdeaTest() {
+  private val underTest = BizGenAppSettingsPersistent()
+
+  @Test
+  fun `Should return current state`() {
+    val settings = BizGenAppSettings()
+    underTest.settings = settings
+    
+    underTest.state shouldBe settings
+  }
+
+  @Test
+  fun `Should load state when action IDs match`(@TestDisposable disposable: Disposable) {
+    val provider = replaceServiceInApp<GeneratorActionProvider>(disposable)
+    val action = mockk<GeneratorAction<*>>(relaxed = true)
+
+    every { action.id } returns "test-id"
+    every { provider.getActions() } returns listOf(action)
+
+    val newSettings = BizGenAppSettings()
+    newSettings.actualActions = mutableListOf(PersistenceActionSetting(id = "test-id"))
+
+    underTest.loadState(newSettings)
+
+    underTest.settings shouldBe newSettings
+  }
+
+  @Test
+  fun `Should restore from default when action IDs do not match`(@TestDisposable disposable: Disposable) {
+    val provider = replaceServiceInApp<GeneratorActionProvider>(disposable)
+
+    every { provider.getActions() } returns emptyList()
+
+    val newSettings = object : BizGenAppSettings() {
+      var restoreCalled = false
+      override fun restoreFromDefault() {
+        restoreCalled = true
+      }
+    }
+
+    newSettings.actualActions = mutableListOf(PersistenceActionSetting(id = "missing-id"))
+
+    underTest.loadState(newSettings)
+
+    newSettings.restoreCalled shouldBe true
+    underTest.settings shouldBe newSettings
+  }
+}


### PR DESCRIPTION
Действия (Actions):
- Исправлена потокобезопасность в GeneratorAction: доступ к модели редактора перенесен в WriteCommandAction.
- Рефакторинг BizGenMainAction: логика попапа вынесена в отдельный метод для обеспечения тестируемости.
- Добавлены интеграционные тесты для основных компонент (исключение только ui часть).

Сервисы и утилиты:
- Добавлены интеграционные тесты для BizGenMainAction и BizGenSelectedActionEvent.
- Добавлены тесты для AppActionSettingsService, BizGenClipboardSettingsService и BizGenAppSettingsPersistent.
- Добавлены тесты для NotificationService (проверка режимов BELL, HINT, DISABLE).
- Добавлены модульные тесты для метода deepCopyByJson.
- BizGenAppSettings и его методы сделаны открытыми (open) для корректного тестирования.

Тестирование (Инфраструктура и Стабильность):
- Реализована базовая обертка для интеграционных тестов BaseIdeaTest.

CI/CD & Сборка & Совместимость:
- Разделен ci-fast.yml на ci-dev.yml (ветка dev) и ci-main.yml (ветка main).
- В воркфлоу для main добавлен обязательный шаг verifyPlugin.
- В настройках Kover (build.gradle.kts) исключен пакет ru.eda.plgn.bizgen.ui из расчета покрытия.
- Исправлен формат sinceBuild. Теперь проставляется "242" для совместимости с IDEA 2024.2+.
- Плагин переведён на 252 платформу

Документация:
- В description.html добавлены английские ключевые слова для лучшего ранжирования в Marketplace.
- Актуализирован список генераторов (СНИЛС, номер карты, форматы ОКТМО).
- Добавлена информация о вызове через Search Everywhere (Shift+Shift).

Closes #37