### PR TITLE
feat: новый механизм обновления настроек

### DIFF
--- a/ru-bizgen-core/src/main/kotlin/ru/eda/plgn/bizgen/core/generator_info/GeneratorInfoProvider.kt
+++ b/ru-bizgen-core/src/main/kotlin/ru/eda/plgn/bizgen/core/generator_info/GeneratorInfoProvider.kt
@@ -34,6 +34,8 @@ import ru.eda.plgn.bizgen.core.generator_info.impl.swift.Swift8GeneratorInfo
  * @author Dmitry_Emelyanenko
  */
 object GeneratorInfoProvider {
+
+  /** Список информаций о доступных генераторах. */
   val generatorInfos: List<GeneratorInfo<*>> = listOf(
     // Технические
     UuidGeneratorInfo(),

--- a/ru-bizgen-perf/src/jmh/kotlin/ru/eda/plgn/bizgen/perf/bench/BaseGeneratorBenchmark.kt
+++ b/ru-bizgen-perf/src/jmh/kotlin/ru/eda/plgn/bizgen/perf/bench/BaseGeneratorBenchmark.kt
@@ -59,11 +59,17 @@ import java.util.concurrent.TimeUnit
 abstract class BaseGeneratorBenchmark<T : Any>(private val generatorSupplier: () -> Generator<T>) {
   private lateinit var generator: Generator<T>
 
+  /** Подготовка генератора к тестированию. */
   @Setup
   fun setup() {
     generator = generatorSupplier()
   }
 
+  /**
+   * Тестирование работы генератора.
+   *
+   * @return сгенерированное значение
+   */
   @Benchmark
   fun generate(): String {
     return generator.generate().toEditor

--- a/ru-bizgen-perf/src/main/kotlin/ru/eda/plgn/bizgen/perf/jmh/report/data/JmhScoreSerializer.kt
+++ b/ru-bizgen-perf/src/main/kotlin/ru/eda/plgn/bizgen/perf/jmh/report/data/JmhScoreSerializer.kt
@@ -20,10 +20,17 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 object JmhScoreSerializer : KSerializer<Double?> {
 
+  /** Описание кастомного сериализатора. */
   @OptIn(InternalSerializationApi::class)
   override val descriptor: SerialDescriptor =
     buildSerialDescriptor("JmhScore", SerialKind.CONTEXTUAL)
 
+  /**
+   * Извлечение [Double].
+   *
+   * @param decoder декодер
+   * @return полученное значение [Double]
+   */
   override fun deserialize(decoder: Decoder): Double? {
     val jsonDecoder = decoder as? JsonDecoder
       ?: error("JmhScoreSerializer can be used only with Json")
@@ -40,6 +47,12 @@ object JmhScoreSerializer : KSerializer<Double?> {
     }
   }
 
+  /**
+   * Сериализация.
+   *
+   * @param encoder примитив
+   * @param value исходное значение, которое необходимо преобразовать
+   */
   override fun serialize(encoder: Encoder, value: Double?) {
     val jsonEncoder = encoder as? JsonEncoder
       ?: error("JmhScoreSerializer can be used only with Json")

--- a/ru-bizgen-perf/src/main/kotlin/ru/eda/plgn/bizgen/perf/jmh/report/service/ReportMdConfigurer.kt
+++ b/ru-bizgen-perf/src/main/kotlin/ru/eda/plgn/bizgen/perf/jmh/report/service/ReportMdConfigurer.kt
@@ -9,10 +9,13 @@ import ru.eda.plgn.bizgen.perf.jmh.report.data.ResultReportData
  * @author Dmitry_Emelyanenko
  */
 object ReportMdConfigurer {
+
+  /** Провайдер генераторов. Ключ - название класса генератора. Значение - название генератора. */
   val provider = GeneratorInfoProvider.generatorInfos.associate { info ->
     info.generator.javaClass.simpleName to info.name
   }
 
+  /** Приоритет. Ключ - название класса генератора. Значение - исходный индекс генератора. */
   val priority = GeneratorInfoProvider.generatorInfos.mapIndexed { index, info ->
     info.generator.javaClass.simpleName to index
   }.toMap()

--- a/ru-bizgen-plugin/build.gradle.kts
+++ b/ru-bizgen-plugin/build.gradle.kts
@@ -18,7 +18,10 @@ plugins {
   alias(libs.plugins.gradleIntelliJPlugin)
 }
 
-val buildNumber = rootProject.version.toString().substringAfterLast(".").take(3)
+group = rootProject.group
+version = rootProject.version
+
+val buildNumber = version.toString().substringAfterLast(".").take(3)
 val ideaVersion = "20" + buildNumber.take(2) + "." + buildNumber.last().toString()
 
 kotlin {

--- a/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/notification/NotificationService.kt
+++ b/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/notification/NotificationService.kt
@@ -17,7 +17,10 @@ import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings
  *
  * @author Dmitry_Emelyanenko
  */
-interface NotificationService : BizGenService {
+interface NotificationService : Notificator, BizGenService
+
+/** Отправка уведомлений. */
+interface Notificator {
 
   /**
    * Отправить уведомление.
@@ -37,7 +40,7 @@ class NotificationServiceImpl : NotificationService {
   }
 
   private companion object {
-    fun getNotificator(mode: BizGenAppSettings.BizGenNotificationMode): NotificationService {
+    fun getNotificator(mode: BizGenAppSettings.BizGenNotificationMode): Notificator {
       return when (mode) {
         BizGenAppSettings.BizGenNotificationMode.BELL -> BellNotification()
         BizGenAppSettings.BizGenNotificationMode.HINT -> HintNotification()
@@ -48,7 +51,7 @@ class NotificationServiceImpl : NotificationService {
 }
 
 /** Уведомление через всплывающую подсказку. */
-private class HintNotification : NotificationService {
+private class HintNotification : Notificator {
   override fun sendNotification(ctx: NotificationCtx<*>) {
     JBPopupFactory.getInstance()
       .createHtmlTextBalloonBuilder(bufferInfo(ctx.result, textLimit = 255), null, JBColor.background(), null)
@@ -62,7 +65,7 @@ private class HintNotification : NotificationService {
 }
 
 /** Уведомление через стандартный механизм уведомлений (колокольчик). */
-private class BellNotification : NotificationService {
+private class BellNotification : Notificator {
   override fun sendNotification(ctx: NotificationCtx<*>) {
     ApplicationManager.getApplication().messageBus.syncPublisher(Notifications.TOPIC).notify(
       Notification(" ", "Generator: ${ctx.actionInfo.name}", bufferInfo(ctx.result, textLimit = null), NotificationType.INFORMATION)
@@ -71,7 +74,7 @@ private class BellNotification : NotificationService {
 }
 
 /** Не отправлять уведомление. */
-private class SkipNotification : NotificationService {
+private class SkipNotification : Notificator {
   override fun sendNotification(ctx: NotificationCtx<*>) = Unit
 }
 

--- a/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsPersistent.kt
+++ b/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsPersistent.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.SettingsCategory
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import ru.eda.plgn.bizgen.plugin.actions.GeneratorActionProvider
+import com.intellij.openapi.diagnostic.Logger
 import ru.eda.plgn.bizgen.plugin.di.getBizGenService
 import ru.eda.plgn.bizgen.plugin.settings.BizGenAppSettingsRepository
 import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings
@@ -26,17 +26,22 @@ internal class BizGenAppSettingsPersistent(
   var settings: BizGenAppSettings = BizGenAppSettings(),
 ) : PersistentStateComponent<BizGenAppSettings>, BizGenAppSettingsRepository {
 
-  override fun getState(): BizGenAppSettings {
-    return settings
-  }
+  private val log = Logger.getInstance(this::class.java)
+
+  override fun getState(): BizGenAppSettings = settings
 
   override fun loadState(bizGenAppSettings: BizGenAppSettings) {
-    // если сохраненное количество действий не равно общему количеству актуальных действий,
-    // то происходит автоматическое восстановление настроек по умолчанию
-    val persistentActionIds = bizGenAppSettings.actualActions.map { it.id }
-    val availableActionsIds = getBizGenService<GeneratorActionProvider>().getInfos().map { it.id }
+    try {
+      // Мягкая миграция
+      val updatedActions = getBizGenService<BizGenAppSettingsSoftUpdater>().softUpdateActions(bizGenAppSettings.actualActions)
 
-    if (persistentActionIds != availableActionsIds) {
+      bizGenAppSettings.actualActions = updatedActions
+    } catch (ex: Exception) {
+      log.warn("Failed to soft update actions", ex)
+      bizGenAppSettings.restoreFromDefault()
+    }
+
+    if (bizGenAppSettings.actualActions.isEmpty()) {
       bizGenAppSettings.restoreFromDefault()
     }
 

--- a/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsSoftUpdater.kt
+++ b/ru-bizgen-plugin/src/main/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsSoftUpdater.kt
@@ -1,0 +1,112 @@
+package ru.eda.plgn.bizgen.plugin.settings.persistent
+
+import ru.eda.plgn.bizgen.plugin.actions.GeneratorActionProvider
+import ru.eda.plgn.bizgen.plugin.di.BizGenService
+import ru.eda.plgn.bizgen.plugin.di.getBizGenService
+import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings.ActionSettingsView
+import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings.PersistenceActionSetting
+
+/**
+ * Мягкое обновление настроек генераторов.
+ *
+ * @author Dmitry_Emelyanenko
+ */
+fun interface BizGenAppSettingsSoftUpdater : BizGenService {
+
+  /**
+   * Обновление сохраненных генераторов.
+   *
+   * Процесс обновления выглядит следующим образом:
+   * - Удаление генератора, если он отсутствует среди доступных
+   * - Если есть среди доступных, то оставляем состояние активности и позицию без изменений и обновляем только название (на всякий случай)
+   * - Новые генераторы добавляем в конец и по умолчанию делаем их активными
+   *
+   * @param savedActions загружаемые настройки генераторов
+   * @return обновленные настройки генераторов
+   */
+  fun softUpdateActions(savedActions: MutableList<PersistenceActionSetting>): MutableList<PersistenceActionSetting>
+}
+
+/** Реализация [BizGenAppSettingsSoftUpdater]. */
+class BizGenAppSettingsSoftUpdaterImpl : BizGenAppSettingsSoftUpdater {
+
+  override fun softUpdateActions(savedActions: MutableList<PersistenceActionSetting>): MutableList<PersistenceActionSetting> {
+    val actualActions = getActualActions()
+
+    removeNotActualActions(savedActions, actualActions)
+    updateActualActions(savedActions, actualActions)
+    addNewActualActions(savedActions, actualActions)
+
+    return savedActions
+  }
+
+  private fun addNewActualActions(savedActions: MutableList<PersistenceActionSetting>, actualActions: List<ActionSettingsView>) {
+    val nextPosition = savedActions.maxOfOrNull { it.position }?.let { it + 1 } ?: 0
+    val savedActionids = savedActions.map { it.id }
+
+    actualActions
+      .filter { it.id !in savedActionids }
+      .forEachIndexed { index, newAction ->
+        savedActions.add(
+          PersistenceActionSetting(
+            id = newAction.id,
+            position = index + nextPosition,
+            description = newAction.description,
+            active = true,
+          )
+        )
+      }
+  }
+
+  private companion object {
+    val notActualCriteria: (PersistenceActionSetting, List<ActionSettingsView>) -> Boolean = { current, actuals ->
+      current.id !in actuals.map { it.id }
+    }
+
+    fun removeNotActualActions(saved: MutableList<PersistenceActionSetting>, actual: List<ActionSettingsView>) {
+      // находим позиции действий, которые потеряли актуальность
+      val notActualActionPositions = saved.filter { notActualCriteria(it, actual) }.map { it.position }
+
+      // удаляем неактуальные действия
+      saved.removeIf { notActualCriteria(it, actual) }
+
+      restorePositions(saved, notActualActionPositions)
+    }
+
+    fun updateActualActions(saved: List<PersistenceActionSetting>, actuals: List<ActionSettingsView>) {
+      val actualsById = actuals.associateBy { it.id }
+
+      saved.forEach { savedAction ->
+        actualsById[savedAction.id]?.let { actual ->
+          savedAction.apply { description = actual.description }
+        }
+      }
+    }
+
+    fun restorePositions(saved: List<PersistenceActionSetting>, removedPositions: List<Int>) {
+      return saved.forEach { action ->
+        /*
+        Определяем сколько было удалено действий относительно позиции текущего действия.
+        Например:
+        1) Текущая позиция = 5
+        2) Были удалены позиции 1,4,6,8
+        3) Получается, что наша позиция должна сместиться на 2, так как её затрагивает удаление первой и четвертой позиций
+         */
+        val fondShift = removedPositions.filter { removeIndex -> removeIndex < action.position }.size
+
+        action.position -= fondShift
+      }
+    }
+
+    fun getActualActions(): List<ActionSettingsView> {
+      return getBizGenService<GeneratorActionProvider>().getInfos().map { info ->
+        PersistenceActionSetting(
+          id = info.id,
+          position = -1,
+          description = info.name,
+          active = true
+        )
+      }
+    }
+  }
+}

--- a/ru-bizgen-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ru-bizgen-plugin/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,11 @@
       serviceImplementation="ru.eda.plgn.bizgen.plugin.clipboard.BizGenClipboardSettingsServiceImpl"
     />
 
+    <applicationService
+      serviceInterface="ru.eda.plgn.bizgen.plugin.settings.persistent.BizGenAppSettingsSoftUpdater"
+      serviceImplementation="ru.eda.plgn.bizgen.plugin.settings.persistent.BizGenAppSettingsSoftUpdaterImpl"
+    />
+
     <applicationConfigurable
       parentId="tools"
       instance="ru.eda.plgn.bizgen.plugin.ui.AppSettingsConfigurable"

--- a/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/BaseTest.kt
+++ b/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/BaseTest.kt
@@ -1,6 +1,10 @@
 package ru.eda.plgn.bizgen.plugin
 
 import org.junit.jupiter.api.DynamicTest
+import org.reflections.Reflections
+import org.reflections.scanners.Scanners
+import java.lang.reflect.Modifier
+import kotlin.reflect.KClass
 
 /**
  * Базовый тестовый класс.
@@ -52,5 +56,12 @@ internal abstract class BaseTest {
         }
       )
     }
+  }
+
+  protected fun <T : Any> findImplemented(baseClass: KClass<T>, scanPackage: String? = null): List<Class<out T>> {
+    return Reflections(scanPackage ?: baseClass.java.packageName, Scanners.SubTypes).getSubTypesOf(baseClass.java).asSequence()
+      .filterNot { it.isInterface || Modifier.isAbstract(it.modifiers) }
+      .filterNot { it.name.contains(".Test") || it.name.contains("Fake") }
+      .toList()
   }
 }

--- a/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/actions/GeneratorActionProviderTest.kt
+++ b/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/actions/GeneratorActionProviderTest.kt
@@ -4,12 +4,8 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
-import org.reflections.Reflections
-import org.reflections.scanners.Scanners
 import ru.eda.plgn.bizgen.core.generator_info.GeneratorInfo
 import ru.eda.plgn.bizgen.plugin.BaseTest
-import java.lang.reflect.Modifier
-import kotlin.reflect.KClass
 
 /**
  * Модульные тесты для [GeneratorActionProvider].
@@ -46,14 +42,5 @@ internal class GeneratorActionProviderTest : BaseTest() {
   internal fun `Should contains all implemented GeneratorAnAction`() {
     // given
     provider.getInfos().size shouldBe provider.getAnActions().size
-  }
-
-  private companion object {
-    fun <T : Any> findImplemented(baseClass: KClass<T>): List<Class<out T>> {
-      return Reflections(baseClass.java.packageName, Scanners.SubTypes).getSubTypesOf(baseClass.java).asSequence()
-        .filterNot { it.isInterface || Modifier.isAbstract(it.modifiers) }
-        .filterNot { it.name.contains(".Test") }
-        .toList()
-    }
   }
 }

--- a/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/di/BizGenServiceTest.kt
+++ b/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/di/BizGenServiceTest.kt
@@ -1,0 +1,31 @@
+package ru.eda.plgn.bizgen.plugin.di
+
+import com.intellij.ide.plugins.PluginMainDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+import io.kotest.matchers.collections.shouldContainAllInAnyOrder
+import org.junit.jupiter.api.Test
+import ru.eda.plgn.bizgen.plugin.BaseIdeaTest
+
+/**
+ * Тест для проверки, что все [BizGenService] зарегистрированы в плагине.
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BizGenServiceTest : BaseIdeaTest() {
+
+  @Test
+  @Suppress("UnstableApiUsage")
+  internal fun `Should verify that all bizGen services are registered in the plugin`() {
+    // given
+    val bizGenPlugin = PluginManagerCore.getPlugin(id = PluginId("ru.eda.plgn.bizgen"))
+    val registryInPlugin =
+      (bizGenPlugin as PluginMainDescriptor).appContainerDescriptor.services.mapNotNull { it.implementation }.toSet()
+
+    // when
+    val bizGenServices = findImplemented(BizGenService::class, "ru.eda.plgn.bizgen").map { it.name }
+
+    // then
+    registryInPlugin shouldContainAllInAnyOrder bizGenServices
+  }
+}

--- a/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsPersistentTest.kt
+++ b/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsPersistentTest.kt
@@ -1,16 +1,18 @@
 package ru.eda.plgn.bizgen.plugin.settings.persistent
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.JDOMUtil
 import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.util.xmlb.XmlSerializer
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
-import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import ru.eda.plgn.bizgen.core.generator_info.GeneratorInfo
-import ru.eda.plgn.bizgen.plugin.actions.GeneratorActionProvider
 import ru.eda.plgn.bizgen.plugin.BaseIdeaTest
 import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings
 import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings.PersistenceActionSetting
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Интеграционные тесты для [BizGenAppSettingsPersistent].
@@ -24,44 +26,56 @@ internal class BizGenAppSettingsPersistentTest : BaseIdeaTest() {
   fun `Should return current state`() {
     val settings = BizGenAppSettings()
     underTest.settings = settings
-    
+
     underTest.state shouldBe settings
   }
 
   @Test
-  fun `Should load state when action IDs match`(@TestDisposable disposable: Disposable) {
-    val provider = replaceServiceInApp<GeneratorActionProvider>(disposable)
-    val action = mockk<GeneratorInfo<*>>(relaxed = true)
+  fun `Should restore from default when updater throw exception`(@TestDisposable disposable: Disposable) {
+    // given
+    underTest.settings = BizGenAppSettings().also { it.restoreFromDefault() }
+    val newSettings = BizGenAppSettings().apply { actualActions = mutableListOf(PersistenceActionSetting(id = "test-id")) }
 
-    every { action.id } returns "test-id"
-    every { provider.getInfos() } returns listOf(action)
+    // and
+    val updater = replaceServiceInApp<BizGenAppSettingsSoftUpdater>(disposable)
+    every { updater.softUpdateActions(any()) } throws Exception("Ops when update actions")
 
-    val newSettings = BizGenAppSettings()
-    newSettings.actualActions = mutableListOf(PersistenceActionSetting(id = "test-id"))
-
+    // when
     underTest.loadState(newSettings)
 
+    // then
     underTest.settings shouldBe newSettings
   }
 
   @Test
-  fun `Should restore from default when action IDs do not match`(@TestDisposable disposable: Disposable) {
-    val provider = replaceServiceInApp<GeneratorActionProvider>(disposable)
+  fun `Should load state when action IDs match`(@TestDisposable disposable: Disposable) {
+    // given
+    val storedActions = mutableListOf<PersistenceActionSetting>()
+    underTest.settings = BizGenAppSettings().also { it.actualActions = storedActions }
+    val newActions = mutableListOf(PersistenceActionSetting(id = "test-id"))
 
-    every { provider.getInfos() } returns emptyList()
+    // and
+    val updater = replaceServiceInApp<BizGenAppSettingsSoftUpdater>(disposable)
+    every { updater.softUpdateActions(storedActions) } returns newActions
 
-    val newSettings = object : BizGenAppSettings() {
-      var restoreCalled = false
-      override fun restoreFromDefault() {
-        restoreCalled = true
-      }
-    }
+    // when
+    underTest.loadState(underTest.settings)
 
-    newSettings.actualActions = mutableListOf(PersistenceActionSetting(id = "missing-id"))
+    // then
+    underTest.settings.actualActions shouldBe newActions
+  }
 
-    underTest.loadState(newSettings)
+  @Test
+  @Suppress("LocalVariableName")
+  fun `Should deserialized correctly xml settings version 1_10`() {
+    val settingsV1_10 = loadSettingsFromFile("bizgen_plugin_settings_v1_10.xml")
 
-    newSettings.restoreCalled shouldBe true
-    underTest.settings shouldBe newSettings
+    settingsV1_10 shouldNotBe null
+  }
+
+  fun loadSettingsFromFile(fileName: String): BizGenAppSettings {
+    return Files.readString(Path.of("src/test/resources/settings/$fileName"))
+      .let(JDOMUtil::load)
+      .let { element -> XmlSerializer.deserialize(element, BizGenAppSettings::class.java) }
   }
 }

--- a/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsSoftUpdaterImplTest.kt
+++ b/ru-bizgen-plugin/src/test/kotlin/ru/eda/plgn/bizgen/plugin/settings/persistent/BizGenAppSettingsSoftUpdaterImplTest.kt
@@ -1,0 +1,77 @@
+package ru.eda.plgn.bizgen.plugin.settings.persistent
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.junit5.TestDisposable
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import ru.eda.plgn.bizgen.core.generator.GeneratorResult
+import ru.eda.plgn.bizgen.core.generator.GeneratorResultAsIs
+import ru.eda.plgn.bizgen.core.generator.GeneratorStr
+import ru.eda.plgn.bizgen.core.generator_info.GeneratorStrInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.BikGeneratorInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.CountryGeneratorInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.KppGeneratorInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.SnilsGeneratorInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.UuidGeneratorInfo
+import ru.eda.plgn.bizgen.core.generator_info.impl.ogrn.OgrnIpGeneratorInfo
+import ru.eda.plgn.bizgen.plugin.BaseIdeaTest
+import ru.eda.plgn.bizgen.plugin.actions.GeneratorActionProvider
+import ru.eda.plgn.bizgen.plugin.settings.model.BizGenAppSettings.PersistenceActionSetting
+
+/**
+ * Интеграционные тесты для [BizGenAppSettingsSoftUpdater].
+ *
+ * @author Dmitry_Emelyanenko
+ */
+internal class BizGenAppSettingsSoftUpdaterTest : BaseIdeaTest() {
+  private val underTest: BizGenAppSettingsSoftUpdater = BizGenAppSettingsSoftUpdaterImpl()
+
+  @Test
+  internal fun `Should update saved actions from actual actions`(@TestDisposable disposable: Disposable) {
+    // given
+    // 0) UUID - не надо обновлять (активно = true), 1) KPP - изменилось имя, 2) Snils - удаляется,
+    // 3) BIK - не надо обновлять (активно = false), 4) COUNTRY - удаляется, 5) OGRN - не надо обновлять (активно = false),
+    // 6) TEST_1 - новое, 7) TEST_2 - новое
+    val oldActionSettings = mutableListOf(kppPAS, snilsPAS, ogrnPAS, uuidPAS, bikPAS, countryPAS)
+
+    // and
+    val actioProvider = replaceServiceInApp<GeneratorActionProvider>(disposable)
+    every { actioProvider.getInfos() } returns listOf(
+      UuidGeneratorInfo(),
+      KppGeneratorInfo(),
+      BikGeneratorInfo(),
+      OgrnIpGeneratorInfo(),
+      Test2GeneratorInfo(),
+      Test1GeneratorInfo(),
+    )
+
+    // when
+    val result = underTest.softUpdateActions(oldActionSettings)
+
+    // then
+    result shouldContainExactlyInAnyOrder listOf(
+      PersistenceActionSetting(id = UuidGeneratorInfo().id, position = 0, description = "UUID как строка", active = true),
+      PersistenceActionSetting(id = KppGeneratorInfo().id, position = 1, description = "КПП (9)", active = true),
+      PersistenceActionSetting(id = BikGeneratorInfo().id, position = 2, description = "БИК (9)", active = false),
+      PersistenceActionSetting(id = OgrnIpGeneratorInfo().id, position = 3, description = "ОГРН ИП (15)", active = false),
+      PersistenceActionSetting(id = Test2GeneratorInfo().id, position = 4, description = "TEST2_GENERATOR", active = true),
+      PersistenceActionSetting(id = Test1GeneratorInfo().id, position = 5, description = "TEST1_GENERATOR", active = true),
+    )
+  }
+
+  private val uuidPAS = PersistenceActionSetting(id = UuidGeneratorInfo().id, position = 0, description = "UUID как строка", active = true)
+  private val kppPAS = PersistenceActionSetting(id = KppGeneratorInfo().id, position = 1, description = "OLD_KPP", active = true)
+  private val snilsPAS = PersistenceActionSetting(id = SnilsGeneratorInfo().id, position = 2, description = "SNILS", active = true)
+  private val bikPAS = PersistenceActionSetting(id = BikGeneratorInfo().id, position = 3, description = "БИК (9)", active = false)
+  private val countryPAS = PersistenceActionSetting(id = CountryGeneratorInfo().id, position = 4, description = "COUNTRY", active = false)
+  private val ogrnPAS = PersistenceActionSetting(id = OgrnIpGeneratorInfo().id, position = 5, description = "ОГРН ИП (15)", active = false)
+
+  private class Test1GeneratorInfo : GeneratorStrInfo(id = "TEST_1", name = "TEST1_GENERATOR", generator = TestGenerator())
+  private class Test2GeneratorInfo : GeneratorStrInfo(id = "TEST_2", name = "TEST2_GENERATOR", generator = TestGenerator())
+  private class TestGenerator : GeneratorStr {
+    override val uniqueDistance: Int = 10
+
+    override fun generate(): GeneratorResult<String> = GeneratorResultAsIs(data = "_TEST_")
+  }
+}

--- a/ru-bizgen-plugin/src/test/resources/settings/bizgen_plugin_settings_v1_10.xml
+++ b/ru-bizgen-plugin/src/test/resources/settings/bizgen_plugin_settings_v1_10.xml
@@ -1,0 +1,134 @@
+<application>
+  <component name="Ru BizGen">
+    <option name="actualActions">
+      <list>
+        <PersistenceActionSetting>
+          <option name="description" value="UUID как строка" />
+          <option name="id" value="UUID_ee2bca00-0586-4a7c-869c-bee1285d0732" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Расчетный RUN счет (20)" />
+          <option name="id" value="AccountRub_0ecdce94-c1e4-447a-8dce-94c1e4747aeb" />
+          <option name="position" value="1" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Расчетный CNY счет (20)" />
+          <option name="id" value="AccountCny_4cedac13-b6fa-4b0a-be68-3503702f1564" />
+          <option name="position" value="2" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ИНН ФЛ (12)" />
+          <option name="id" value="InnIndividual_3aeaffc7-285e-49c2-aaff-c7285e79c299" />
+          <option name="position" value="3" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ИНН ЮЛ (10)" />
+          <option name="id" value="InnLegal_f5e5e2b3-2d14-4e83-a5e2-b32d140e831a" />
+          <option name="position" value="4" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="КПП (9)" />
+          <option name="id" value="Kpp_d04771b5-6e0c-42dc-8771-b56e0ca2dcb9" />
+          <option name="position" value="5" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ОГРН ЮЛ (13)" />
+          <option name="id" value="OgrnLegal_980cb31d-0e3f-4764-bd8e-b7fb9fba6859" />
+          <option name="position" value="6" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ОГРН ИП (15)" />
+          <option name="id" value="OgrnIp_c532c151-6187-4e7d-b2c1-5161877e7d9d" />
+          <option name="position" value="7" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Организация. Русское наименование" />
+          <option name="id" value="OrgRuName_be05a746-5353-434b-a506-b2541be02550" />
+          <option name="position" value="8" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Организация. Английское наименование" />
+          <option name="id" value="OrgEngName_e60c059d-0c7f-49f5-95b9-bcd194b4a327" />
+          <option name="position" value="9" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="БИК (9)" />
+          <option name="id" value="Bik_0060ce01-2ee3-4598-a0ce-012ee38598da" />
+          <option name="position" value="10" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Корреспондентский счёт (20)" />
+          <option name="id" value="BankAccount_9009b9eb-f622-4599-89b9-ebf622559957" />
+          <option name="position" value="11" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="SWIFT RU (8)" />
+          <option name="id" value="SwiftRu8_59ed6b1a-57cf-4e61-ad6b-1a57cf6e616d" />
+          <option name="position" value="12" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="SWIFT RU (11)" />
+          <option name="id" value="SwiftRu11_31ae8329-4566-49d6-ae83-294566e9d6f4" />
+          <option name="position" value="13" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="IBAN RU (33)" />
+          <option name="id" value="IbanRu_13cbe98c-fc00-4a93-8be9-8cfc00ca93d2" />
+          <option name="position" value="14" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="IBAN TR (26)" />
+          <option name="id" value="IbanTurkish_cdb0d09c-2263-407b-b0d0-9c2263007b43" />
+          <option name="position" value="15" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Адрес (индекс, регион, город и тд)" />
+          <option name="id" value="Address_b35bf562-5761-4a5d-ab00-36afca192d7c" />
+          <option name="position" value="16" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Страна (код, название рус+англ, alpha2, alpha3)" />
+          <option name="id" value="Country_d993c531-359d-476e-a1cb-098cc945ea99" />
+          <option name="position" value="17" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ОКТМО (8)" />
+          <option name="id" value="Oktmo8_d683fd6c-23bb-4ccb-83fd-6c23bbaccb89" />
+          <option name="position" value="18" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ОКТМО (11)" />
+          <option name="id" value="Oktmo11_3ea1bc6b-011c-4bdc-a1bc-6b011c1bdc7c" />
+          <option name="position" value="19" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="Номер карты (16)" />
+          <option name="id" value="CardNumber_92bad607-d900-437c-9605-7ededb10022d" />
+          <option name="position" value="20" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ФИО (Фамилия Имя Отчество)" />
+          <option name="id" value="FioFull_497328f4-0f2b-4829-b328-f40f2b2829d0" />
+          <option name="position" value="21" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ФИО (Фамилия И.О.)" />
+          <option name="id" value="FioShort_3d49bf3a-007d-41e5-89bf-3a007d01e5d6" />
+          <option name="position" value="22" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="ФИО (И.О. Фамилия)" />
+          <option name="id" value="FioInitials_a7e234d4-f204-4a16-a234-d4f204fa16b9" />
+          <option name="position" value="24" />
+        </PersistenceActionSetting>
+        <PersistenceActionSetting>
+          <option name="description" value="СНИЛС (11)" />
+          <option name="id" value="Snils_f113955e-a439-4231-9f0f-fd13a6d23459" />
+          <option name="position" value="23" />
+        </PersistenceActionSetting>
+      </list>
+    </option>
+    <option name="insToClipboard" value="false" />
+    <option name="notificationMode" value="HINT" />
+  </component>
+</application>


### PR DESCRIPTION
- Реализовано мягкое обновление настроек генераторов. Старая реализация была в том, что если не совпадает список генераторов, которые сохранены и актуальный список, то сохраненные генераторы перезаписывались актуальным списком. Сейчас: происходит только добавление новых генераторов, для старых остаются настройки такие, какие их выставил пользователь

Closes #58