### PR TITLE
fix(plugin): Отвязан integrationTest от check

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install -y xvfb
 
       - name: Run integration tests
-        run: xvfb-run -a ./gradlew :ru-bizgen-plugin:integrationTest --no-daemon
+        run: xvfb-run -a ./gradlew :ru-bizgen-plugin:integrationTest -PrunIntegrationTests --no-daemon
 
       - name: Upload test results on failure
         if: failure()

--- a/ru-bizgen-plugin/build.gradle.kts
+++ b/ru-bizgen-plugin/build.gradle.kts
@@ -94,6 +94,8 @@ testing {
   }
 }
 
+val runIntegrationTests = providers.gradleProperty("runIntegrationTests").isPresent
+
 val integrationTest by intellijPlatformTesting.testIdeUi.registering {
   task {
     val integrationTestSourceSet = sourceSets.getByName("integrationTest")
@@ -107,6 +109,10 @@ val integrationTest by intellijPlatformTesting.testIdeUi.registering {
       tasks.buildPlugin.get().archiveFile.get().asFile.absolutePath,
     )
     systemProperty("java.net.preferIPv4Stack", "true")
+
+    // Интеграционные тесты (старт IDE + Driver) тяжёлые и запускаются ночью
+    // через ci-integration.yml. По умолчанию отключены, чтобы не попадать в `check`.
+    enabled = runIntegrationTests
   }
 }
 


### PR DESCRIPTION
- Интеграционные тесты (старт IDE + Driver) отключены по умолчанию, включаются свойством -PrunIntegrationTests

- Обновлён ci-integration.yml: ночной запуск передает -PrunIntegrationTests

- Раньше ./gradlew check в PR-воркфлоу тянул тяжёлый integrationTest из-за авто-привязки плагина к lifecycle check